### PR TITLE
Added technical detail about android permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ and other properties (name, firmware version, current state,...).
 
 :information_source: You can also specify timeout for discovery. Default is 2 seconds.
 
+> Note that for device discovery to properly work on Android, you at least need the `INTERNET` permission granted.
+
 ### Connect to the device
 
 ```dart


### PR DESCRIPTION
Because it wasn't documented, wasn't particularly obvious to me, and since it worked in debug and not release (because by default `debug` has the `INTERNET` permission and not `release`), I think it's worthwile to add a note about it in the README.